### PR TITLE
Include the repository field

### DIFF
--- a/zephyr-cli/Cargo.toml
+++ b/zephyr-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 description = "Mercury CLI."
 license = "Apache-2.0"
 edition = "2021"
+repository = "https://github.com/szabgab/rs-zephyr-toolkit"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zephyr-common/Cargo.toml
+++ b/zephyr-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "rs-zephyr-common"
 version = "0.1.2"
 edition = "2021"
 description = "Common structures between the zephyr sdk and vm"
+repository = "https://github.com/szabgab/rs-zephyr-toolkit"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/zephyr-sdk/Cargo.toml
+++ b/zephyr-sdk/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Tommaso De Ponti @ xyclooLabs <tommaso@xycloo.com>"]
 description = "Rust SDK for building Zephyr programs."
 documentation = "https://docs.mercurydata.app/"
 homepage = "https://mercurydata.app/zephyr-vm/"
+repository = "https://github.com/xycloo/rs-zephyr-toolkit"
 keywords = ["wasm", "sdk", "blockchain"]
 license = "Apache-2.0"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.